### PR TITLE
Defer router initialization until persistor is bootstrapped

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -2,15 +2,12 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Provider as ReduxProvider } from 'react-redux';
-import { RouterProvider } from 'react-router-dom';
-import { PersistGate } from 'redux-persist/integration/react';
 import { attachAuthInterceptor } from '~shared/api/api.instance';
 import { queryClient } from '~shared/queryClient';
-import { persistor, store } from '~shared/store';
+import { store } from '~shared/store';
 import { logError } from '~shared/ui/error-handler/error-handler.lib';
 import { ErrorHandler } from '~shared/ui/error-handler/error-handler.ui';
-import { Spinner } from '~shared/ui/spinner/spinner.ui';
-import { browserRouter } from './browser-router';
+import { BootstrappedRouter } from './browser-router';
 
 attachAuthInterceptor(() => store.getState().session?.token);
 
@@ -18,12 +15,10 @@ export default function App() {
   return (
     <ErrorBoundary FallbackComponent={ErrorHandler} onError={logError}>
       <ReduxProvider store={store}>
-        <PersistGate loading={<Spinner />} persistor={persistor}>
-          <QueryClientProvider client={queryClient}>
-            <RouterProvider router={browserRouter} fallbackElement={<Spinner />} />
-            <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" />
-          </QueryClientProvider>
-        </PersistGate>
+        <QueryClientProvider client={queryClient}>
+          <BootstrappedRouter />
+          <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" />
+        </QueryClientProvider>
       </ReduxProvider>
     </ErrorBoundary>
   );

--- a/src/app/browser-router.tsx
+++ b/src/app/browser-router.tsx
@@ -1,5 +1,8 @@
-import { Outlet, createBrowserRouter, redirect, useRouteError } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { Outlet, RouterProvider, createBrowserRouter, redirect, useRouteError } from 'react-router-dom';
 import { pathKeys } from '~shared/router';
+import { persistor } from '~shared/store';
+import { Spinner } from '~shared/ui/spinner/spinner.ui';
 import { articlePageRoute } from '~pages/article/article-page.route';
 import { editorPageRoute } from '~pages/editor/editor-page.route';
 import { homePageRoute } from '~pages/home/home-page.route';
@@ -10,33 +13,58 @@ import { profilePageRoute } from '~pages/profile/profile-page.route';
 import { registerPageRoute } from '~pages/register/register-page.route';
 import { settingsPageRoute } from '~pages/settings/settings-page.route';
 
-export const browserRouter = createBrowserRouter([
-  {
-    errorElement: <BubbleError />,
-    children: [
-      {
-        lazy: lazyLayout,
-        children: [
-          loginPageRoute,
-          registerPageRoute,
-          homePageRoute,
-          articlePageRoute,
-          profilePageRoute,
-          editorPageRoute,
-          settingsPageRoute,
-        ],
-      },
-      {
-        element: <Outlet />,
-        children: [page404Route],
-      },
-      {
-        path: '*',
-        loader: async () => redirect(pathKeys.page404),
-      },
-    ],
-  },
-]);
+export function BootstrappedRouter() {
+  const [router, setRouter] = useState<ReturnType<typeof browserRouter> | null>(null);
+
+  useEffect(() => {
+    if (persistor.getState().bootstrapped) {
+      setRouter(browserRouter());
+    } else {
+      const unsubscribe = persistor.subscribe(() => {
+        if (persistor.getState().bootstrapped) {
+          setRouter(browserRouter());
+          unsubscribe();
+        }
+      });
+      return () => unsubscribe();
+    }
+  }, []);
+
+  if (!router) {
+    return <Spinner />;
+  }
+
+  return <RouterProvider router={router} fallbackElement={<Spinner />} />;
+}
+
+const browserRouter = () =>
+  createBrowserRouter([
+    {
+      errorElement: <BubbleError />,
+      children: [
+        {
+          lazy: lazyLayout,
+          children: [
+            loginPageRoute,
+            registerPageRoute,
+            homePageRoute,
+            articlePageRoute,
+            profilePageRoute,
+            editorPageRoute,
+            settingsPageRoute,
+          ],
+        },
+        {
+          element: <Outlet />,
+          children: [page404Route],
+        },
+        {
+          path: '*',
+          loader: async () => redirect(pathKeys.page404),
+        },
+      ],
+    },
+  ]);
 
 // https://github.com/remix-run/react-router/discussions/10166
 function BubbleError(): null {


### PR DESCRIPTION
- Extracted `browserRouter` logic into a separate `BootstrappedRouter` component.
- Introduced a check for `persistor.getState().bootstrapped` before rendering the router.
- Removed the legacy `PersistGate` wrapper. The `RouterProvider` is now rendered only after the persisted store is fully rehydrated.

Prevents race conditions where the router was initialized before the store was restored from localStorage. This could result in broken navigation flows and missing auth tokens on initial load.

Fixes: #23